### PR TITLE
Fix storage class for message

### DIFF
--- a/src/pack_ppfield.c
+++ b/src/pack_ppfield.c
@@ -48,7 +48,7 @@
 #include "rlencode.h"
 
 // Message buffer for the syslog interface
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 
 // DATA field structure interface
 // pack the data, calling the correct method based on the lookup associated with it

--- a/src/rlencode.c
+++ b/src/rlencode.c
@@ -33,7 +33,7 @@
 #include "wgdosstuff.h"
 #include "logerrors.h"
 
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 #define debug 0
 /*
  * runlenEncode returns RL_OK if success, RL_ERR if input the number of

--- a/src/unpack_ppfield.c
+++ b/src/unpack_ppfield.c
@@ -51,7 +51,7 @@
 
 // Message buffer for the syslog interface
 #define MAX_MESSAGE_SIZE 1024
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 
 // DATA field structure interface
 // unpack the data, calling the correct method based on the lookup associated with it

--- a/src/wgdos_decode_field_parameters.c
+++ b/src/wgdos_decode_field_parameters.c
@@ -82,7 +82,7 @@
 #include "logerrors.h"
 
 #define MAX_MESSAGE_SIZE 1024
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 
 /* End of header */
 

--- a/src/wgdos_decode_row_parameters.c
+++ b/src/wgdos_decode_row_parameters.c
@@ -80,7 +80,7 @@
 #include "logerrors.h"
 
 #define MAX_MESSAGE_SIZE 1024
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 /* End of header */
 
 int wgdos_decode_row_parameters(

--- a/src/wgdos_expand_row_to_data.c
+++ b/src/wgdos_expand_row_to_data.c
@@ -81,7 +81,7 @@
 #define debug 0
 
 #define MAX_MESSAGE_SIZE 1024
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 
 /* End of header */
 

--- a/src/wgdos_pack.c
+++ b/src/wgdos_pack.c
@@ -61,7 +61,7 @@
 #include "wgdosstuff.h"
 #include "logerrors.h"
 
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 /* End of header */
 
 

--- a/src/wgdos_unpack.c
+++ b/src/wgdos_unpack.c
@@ -96,7 +96,7 @@
 #include "logerrors.h"
 
 #define MAX_MESSAGE_SIZE 1024
-char message[MAX_MESSAGE_SIZE];
+static char message[MAX_MESSAGE_SIZE];
 /* End of header */
 
 int wgdos_unpack(


### PR DESCRIPTION
Having these as (implied) `extern` causes problems on OSX. They really should be `static` anyway as they're not intended to be used externally.

NB. Technically this is a removal from the external interface so it should cause the interface number to increase and the revision and age to be set to zero.
