### PR TITLE
remove src double ref

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,5 +5,5 @@ add_library(mo_unpack SHARED convert_float_ibm_to_ieee32.c convert_float_ieee32_
 set_target_properties(mo_unpack PROPERTIES SOVERSION 3)
 
 install(TARGETS mo_unpack DESTINATION lib)
-install(FILES src/wgdosstuff.h DESTINATION include)
+install(FILES wgdosstuff.h DESTINATION include)
 


### PR DESCRIPTION
Minor cmake bug fix.
src/src does not exist

Currently

```
-- Install configuration: ""
-- Installing: /usr/local/sci/lib/libmo_unpack.so.3
-- Up-to-date: /usr/local/sci/lib/libmo_unpack.so
CMake Error at src/cmake_install.cmake:65 (FILE):
  file INSTALL cannot find
  "/usr/local/sci/src/libmo_unpack-3.1/src/src/wgdosstuff.h".
Call Stack (most recent call first):
  cmake_install.cmake:37 (INCLUDE)
```
