### PR TITLE
Added the CMAKE_INCLUDE_PATH path to the test includes.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 enable_testing()
 find_package(Check REQUIRED)
+include_directories(${CMAKE_INCLUDE_PATH})
 include_directories(${CHECK_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${CHECK_LIBRARIES} mo_unpack m rt pthread)
 include_directories(. ../src)


### PR DESCRIPTION
I needed to make this change in order to compile on a system which didn't have check in a standard location. I wanted to add it with the standard `CMAKE_INCLUDE_PATH`, though I suppose I could have added it with `CHECK_INCLUDE_DIRS`...
